### PR TITLE
feat: Make graph types extendable

### DIFF
--- a/src/VirtoCommerce.XRecommend.Core/Schemas/GetRecentlyBrowsedResponseType.cs
+++ b/src/VirtoCommerce.XRecommend.Core/Schemas/GetRecentlyBrowsedResponseType.cs
@@ -1,13 +1,14 @@
 using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Schemas;
 using VirtoCommerce.XRecommend.Core.Models;
 
 namespace VirtoCommerce.XRecommend.Core.Schemas;
 
-public class GetRecentlyBrowsedResponseType : ObjectGraphType<GetRecentlyBrowsedResult>
+public class GetRecentlyBrowsedResponseType : ExtendableGraphType<GetRecentlyBrowsedResult>
 {
     public GetRecentlyBrowsedResponseType()
     {
-        Field<ListGraphType<ProductType>>("products", resolve: context => context.Source.Products);
+        ExtendableField<ListGraphType<ProductType>>("products", resolve: context => context.Source.Products);
     }
 }

--- a/src/VirtoCommerce.XRecommend.Core/Schemas/GetRecommendationsResponseType.cs
+++ b/src/VirtoCommerce.XRecommend.Core/Schemas/GetRecommendationsResponseType.cs
@@ -1,13 +1,14 @@
 using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.XCatalog.Core.Schemas;
 using VirtoCommerce.XRecommend.Core.Models;
 
 namespace VirtoCommerce.XRecommend.Core.Schemas;
 
-public class GetRecommendationsResponseType : ObjectGraphType<GetRecommendationsResult>
+public class GetRecommendationsResponseType : ExtendableGraphType<GetRecommendationsResult>
 {
     public GetRecommendationsResponseType()
     {
-        Field<ListGraphType<ProductType>>("products", resolve: context => context.Source.Products);
+        ExtendableField<ListGraphType<ProductType>>("products", resolve: context => context.Source.Products);
     }
 }


### PR DESCRIPTION
## Description
Make graph types extendable
- GetRecentlyBrowsedResponseType
- GetRecommendationsResponseType
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XRecommend_3.803.0-pr-6-8293.zip