### PR TITLE
VCST-2376: update GraphQL.NET to v8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.806.0</VersionPrefix>
+    <VersionPrefix>3.900.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
+++ b/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.816.0-alpha.74-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.822.0-alpha.61-vcst-2376-update-graphql" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
+++ b/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.817.0-alpha.79-vcst-2376-update-graphql" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.822.0-alpha.63-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.900.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.900.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
+++ b/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.816.0-alpha.74-vcst-2376-update-graphql" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.822.0-alpha.61-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.817.0-alpha.79-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.822.0-alpha.63-vcst-2376-update-graphql" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XRecommend.Data/Queries/GetRecommendationsQueryHandler.cs
+++ b/src/VirtoCommerce.XRecommend.Data/Queries/GetRecommendationsQueryHandler.cs
@@ -9,7 +9,6 @@ using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.XCatalog.Core.Queries;
-using VirtoCommerce.XDigitalCatalog.Queries;
 using VirtoCommerce.XRecommend.Core;
 using VirtoCommerce.XRecommend.Core.Models;
 using VirtoCommerce.XRecommend.Core.Queries;

--- a/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
+++ b/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.841.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.822.0-alpha.61-vcst-2376-update-graphql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Core\VirtoCommerce.XRecommend.Core.csproj" />

--- a/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
+++ b/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.841.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.822.0-alpha.61-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.822.0-alpha.63-vcst-2376-update-graphql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Core\VirtoCommerce.XRecommend.Core.csproj" />

--- a/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
+++ b/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.841.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.822.0-alpha.63-vcst-2376-update-graphql" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.900.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Core\VirtoCommerce.XRecommend.Core.csproj" />

--- a/src/VirtoCommerce.XRecommend.Web/Module.cs
+++ b/src/VirtoCommerce.XRecommend.Web/Module.cs
@@ -1,4 +1,5 @@
 using System;
+using GraphQL.MicrosoftDI;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
@@ -8,7 +9,6 @@ using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.XRecommend.Core;
 using VirtoCommerce.XRecommend.Core.Services;
 using VirtoCommerce.XRecommend.Data;
@@ -28,8 +28,10 @@ public class Module : IModule, IHasConfiguration
 
     public void Initialize(IServiceCollection serviceCollection)
     {
-        var graphQLBuilder = new CustomGraphQLBuilder(serviceCollection);
-        graphQLBuilder.AddSchema(typeof(CoreAssemblyMarker), typeof(DataAssemblyMarker));
+        _ = new GraphQLBuilder(serviceCollection, builder =>
+        {
+            builder.AddSchema(serviceCollection, typeof(CoreAssemblyMarker), typeof(DataAssemblyMarker));
+        });
 
         var databaseProvider = Configuration.GetValue("DatabaseProvider", "SqlServer");
         serviceCollection.AddDbContext<XRecommendDbContext>(options =>

--- a/src/VirtoCommerce.XRecommend.Web/module.manifest
+++ b/src/VirtoCommerce.XRecommend.Web/module.manifest
@@ -6,8 +6,8 @@
 
   <platformVersion>3.841.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.800.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.800.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.816.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.822.0" />
   </dependencies>
 
   <title>Product Recommendations</title>

--- a/src/VirtoCommerce.XRecommend.Web/module.manifest
+++ b/src/VirtoCommerce.XRecommend.Web/module.manifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.XRecommend</id>
-  <version>3.806.0</version>
+  <version>3.900.0</version>
   <version-tag></version-tag>
 
   <platformVersion>3.841.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.816.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.822.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.900.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.900.0" />
   </dependencies>
 
   <title>Product Recommendations</title>
@@ -28,7 +28,7 @@
   <moduleType>VirtoCommerce.XRecommend.Web.Module, VirtoCommerce.XRecommend.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2024 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024-2025 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-2376
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XRecommend_3.900.0-pr-10-bde5.zip