### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.905.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
+++ b/src/VirtoCommerce.XRecommend.Core/VirtoCommerce.XRecommend.Core.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.906.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.908.0" />
+    
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XRecommend.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.XRecommend.Data.MySql/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.XRecommend.Data.Repositories.XRecommendDbContext -Project VirtoCommerce.XRecommend.Data.MySql -StartupProject VirtoCommerce.XRecommend.Data.MySql -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.XRecommend.Data.MySql/VirtoCommerce.XRecommend.Data.MySql.csproj
+++ b/src/VirtoCommerce.XRecommend.Data.MySql/VirtoCommerce.XRecommend.Data.MySql.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.877.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Data\VirtoCommerce.XRecommend.Data.csproj" />

--- a/src/VirtoCommerce.XRecommend.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.XRecommend.Data.PostgreSql/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.XRecommend.Data.Repositories.XRecommendDbContext -Project VirtoCommerce.XRecommend.Data.PostgreSql -StartupProject VirtoCommerce.XRecommend.Data.PostgreSql -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.XRecommend.Data.PostgreSql/VirtoCommerce.XRecommend.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.XRecommend.Data.PostgreSql/VirtoCommerce.XRecommend.Data.PostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.877.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Data\VirtoCommerce.XRecommend.Data.csproj" />

--- a/src/VirtoCommerce.XRecommend.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.XRecommend.Data.SqlServer/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.XRecommend.Data.Repositories.XRecommendDbContext -Project VirtoCommerce.XRecommend.Data.SqlServer -StartupProject VirtoCommerce.XRecommend.Data.SqlServer -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.XRecommend.Data.SqlServer/VirtoCommerce.XRecommend.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.XRecommend.Data.SqlServer/VirtoCommerce.XRecommend.Data.SqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.877.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Data\VirtoCommerce.XRecommend.Data.csproj" />

--- a/src/VirtoCommerce.XRecommend.Data/Queries/GetRecommendationsQueryHandler.cs
+++ b/src/VirtoCommerce.XRecommend.Data/Queries/GetRecommendationsQueryHandler.cs
@@ -44,7 +44,7 @@ public class GetRecommendationsQueryHandler : IQueryHandler<GetRecommendationsQu
             return result;
         }
 
-        var _recommendService = _recommendServices.FirstOrDefault(x => x.Model.EqualsInvariant(request.Model));
+        var _recommendService = _recommendServices.FirstOrDefault(x => x.Model.EqualsIgnoreCase(request.Model));
         if (_recommendService != null)
         {
             var recommendationsCriteria = GetRelatedProductsCriteria(request);

--- a/src/VirtoCommerce.XRecommend.Data/Services/RelatedProductsRecommendationsService.cs
+++ b/src/VirtoCommerce.XRecommend.Data/Services/RelatedProductsRecommendationsService.cs
@@ -31,7 +31,7 @@ public class RelatedProductsRecommendationsService : IRecommendationsService
     public async Task<IList<string>> GetRecommendationsAsync(GetRecommendationsCriteria criteria)
     {
         // check ES8, ES9 enabled and return mock result if not (temporary)
-        if (!_configuration.SearchProviderActive("ElasticSearch8") ||
+        if (!_configuration.SearchProviderActive("ElasticSearch8") &&
             !_configuration.SearchProviderActive("ElasticSearch9"))
         {
             var builder = new IndexSearchRequestBuilder()
@@ -138,7 +138,7 @@ public class RelatedProductsRecommendationsService : IRecommendationsService
             .WithIncludeFields("_id");
 
         builder.AddTermFilter("status", "visible");
-        builder.AddTermFilter("__outline", "catalogId");
+        builder.AddTermFilter("__outline", catalogId);
 
         return builder.Build();
     }

--- a/src/VirtoCommerce.XRecommend.Data/Services/RelatedProductsRecommendationsService.cs
+++ b/src/VirtoCommerce.XRecommend.Data/Services/RelatedProductsRecommendationsService.cs
@@ -21,8 +21,6 @@ public class RelatedProductsRecommendationsService : IRecommendationsService
 
     public string Model { get; set; } = "related-products";
 
-    private static readonly string[] StatusVisible = ["status:visible"];
-
     public RelatedProductsRecommendationsService(IStoreService storeService, ISearchProvider searchProvider, IConfiguration configuration)
     {
         _searchProvider = searchProvider;
@@ -32,8 +30,9 @@ public class RelatedProductsRecommendationsService : IRecommendationsService
 
     public async Task<IList<string>> GetRecommendationsAsync(GetRecommendationsCriteria criteria)
     {
-        // check ES8 enabled and return mock result if not (temporary)
-        if (!_configuration.SearchProviderActive("ElasticSearch8"))
+        // check ES8, ES9 enabled and return mock result if not (temporary)
+        if (!_configuration.SearchProviderActive("ElasticSearch8") ||
+            !_configuration.SearchProviderActive("ElasticSearch9"))
         {
             var builder = new IndexSearchRequestBuilder()
                 .WithStoreId(criteria.StoreId)
@@ -138,8 +137,8 @@ public class RelatedProductsRecommendationsService : IRecommendationsService
             .WithSearchPhrase(content)
             .WithIncludeFields("_id");
 
-        builder.AddTerms(StatusVisible);
-        builder.AddTerms(new[] { $"__outline:{catalogId}" });
+        builder.AddTermFilter("status", "visible");
+        builder.AddTermFilter("__outline", "catalogId");
 
         return builder.Build();
     }

--- a/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
+++ b/src/VirtoCommerce.XRecommend.Data/VirtoCommerce.XRecommend.Data.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.877.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.908.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XRecommend.Core\VirtoCommerce.XRecommend.Core.csproj" />

--- a/src/VirtoCommerce.XRecommend.Web/VirtoCommerce.XRecommend.Web.csproj
+++ b/src/VirtoCommerce.XRecommend.Web/VirtoCommerce.XRecommend.Web.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->

--- a/src/VirtoCommerce.XRecommend.Web/module.manifest
+++ b/src/VirtoCommerce.XRecommend.Web/module.manifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.XRecommend</id>
-  <version>3.905.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.877.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.906.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.908.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />
   </dependencies>
 
   <title>Product Recommendations</title>
@@ -28,7 +28,7 @@
   <moduleType>VirtoCommerce.XRecommend.Web.Module, VirtoCommerce.XRecommend.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2024–2025 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024–2026 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.XRecommend.Tests/VirtoCommerce.XRecommend.Tests.csproj
+++ b/tests/VirtoCommerce.XRecommend.Tests/VirtoCommerce.XRecommend.Tests.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.XRecommend.Core\VirtoCommerce.XRecommend.Core.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XRecommend_3.1000.0-pr-20-4244.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a runtime/platform upgrade (net8→net10) with broad dependency bumps, which can introduce compatibility/build/runtime issues. Minor search/query behavior changes (ES9 enablement and new term-filter API) could affect recommendation results.
> 
> **Overview**
> Upgrades the module to **.NET 10** across all projects (including tests), bumps the module version to `3.1000.0`, and aligns VirtoCommerce dependencies (`Platform.Data`/DB providers to `3.1002.0`, `Xapi`/`XCatalog` to `3.1000.0`). EF tooling guidance and design-time packages are updated to `dotnet-ef`/EF Core `10.0.1`, with `NU1608` suppressed in several projects.
> 
> Behavioral updates include making recommendation model selection case-insensitive via `EqualsIgnoreCase`, adding ElasticSearch9 as a supported provider in `RelatedProductsRecommendationsService`, and switching product visibility/catalog filters from `AddTerms` to explicit `AddTermFilter` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42444ea7ae547433c817bf6ddddf7e04072c9971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->